### PR TITLE
[Feat] 지인 등록/삭제/조회/수정

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -35,6 +35,7 @@ import { AppService } from './app.service';
     }),
     AuthModule,
     UserModule,
+    ContactModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/contact/contact.controller.spec.ts
+++ b/src/contact/contact.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ContactController } from './contact.controller';
+
+describe('ContactController', () => {
+  let controller: ContactController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ContactController],
+    }).compile();
+
+    controller = module.get<ContactController>(ContactController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/contact/contact.controller.ts
+++ b/src/contact/contact.controller.ts
@@ -1,0 +1,70 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseArrayPipe,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { AuthUser } from 'src/auth/decorator/auth-user.docrator';
+import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
+import { User } from 'src/entities/user.entity';
+import { ContactService } from './contact.service';
+import { AddContactDto } from './dto/add-contact.dto';
+import { ChangeSendingTargetDto } from './dto/change-sending-target.dto';
+import { ContactListDto } from './dto/contact.dto';
+
+@Controller('contact')
+export class ContactController {
+  constructor(private readonly contactService: ContactService) {}
+
+  @ApiBearerAuth()
+  @Post('/')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '지인 연락처 등록' })
+  async addContacts(
+    @Body(new ParseArrayPipe({ items: AddContactDto }))
+    contactsDto: AddContactDto[],
+    @AuthUser() user: User,
+  ) {
+    return this.contactService.addContacts(user, contactsDto);
+  }
+
+  @ApiBearerAuth()
+  @Get('/')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '지인 연락처 조회' })
+  async getContacts(@AuthUser() user: User): Promise<ContactListDto> {
+    return this.contactService.getContacts(user.id);
+  }
+
+  @ApiBearerAuth()
+  @Delete('/:id')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '지인 연락처 삭제' })
+  async deleteContact(
+    @AuthUser() user: User,
+    @Param('id', ParseIntPipe) contactId: number,
+  ) {
+    return this.contactService.deleteContact(user.id, contactId);
+  }
+
+  @ApiBearerAuth()
+  @Patch('/')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '알림 전송 여부 수정' })
+  async changeSendingTarget(
+    @AuthUser() user: User,
+    @Body() changeSendingTargetDto: ChangeSendingTargetDto,
+  ) {
+    return this.contactService.changeSendingTarget(
+      user.id,
+      changeSendingTargetDto,
+    );
+  }
+}

--- a/src/contact/contact.module.ts
+++ b/src/contact/contact.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { ContactService } from './contact.service';
+import { ContactController } from './contact.controller';
+import { ContactRepository } from 'src/repositories/contact.repository';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Contact } from 'src/entities/contact.entity';
+import { UserRepository } from 'src/repositories/user.repository';
+import { User } from 'src/entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Contact, User])],
+  providers: [ContactService, ContactRepository, UserRepository],
+  controllers: [ContactController],
+})
+export class ContactModule {}

--- a/src/contact/contact.service.spec.ts
+++ b/src/contact/contact.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ContactService } from './contact.service';
+
+describe('ContactService', () => {
+  let service: ContactService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ContactService],
+    }).compile();
+
+    service = module.get<ContactService>(ContactService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/contact/contact.service.ts
+++ b/src/contact/contact.service.ts
@@ -1,0 +1,84 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Contact } from 'src/entities/contact.entity';
+import { User } from 'src/entities/user.entity';
+import { ContactRepository } from 'src/repositories/contact.repository';
+import { UserRepository } from 'src/repositories/user.repository';
+import { AddContactDto } from './dto/add-contact.dto';
+import { ChangeSendingTargetDto } from './dto/change-sending-target.dto';
+import { ContactDto, ContactListDto } from './dto/contact.dto';
+
+@Injectable()
+export class ContactService {
+  constructor(
+    private readonly contactRepository: ContactRepository,
+    private readonly userRepository: UserRepository,
+  ) {}
+
+  async addContacts(user: User, contactsDto: AddContactDto[]): Promise<void> {
+    contactsDto.forEach(async (contact: AddContactDto) => {
+      const { name, phoneNumber } = contact;
+
+      const contactExist =
+        await this.contactRepository.findContactByPhoneNumber(
+          user.id,
+          phoneNumber,
+        );
+
+      if (contactExist) {
+        throw new ConflictException(
+          `The contact ${phoneNumber} already exists`,
+        );
+      }
+
+      await this.contactRepository.createContact(user, name, phoneNumber);
+    });
+
+    return;
+  }
+
+  async getContacts(userId: number): Promise<ContactListDto> {
+    const contacts = await this.contactRepository.getContacts(userId);
+
+    const contactWithIsUser = await Promise.all(
+      contacts.map(async (contact: Contact) => {
+        const user = await this.userRepository.findUserByPhoneNumber(
+          contact.phoneNumber,
+        );
+
+        return { ...contact, isUser: user ? true : false } as ContactDto;
+      }),
+    );
+
+    return { contacts: contactWithIsUser };
+  }
+
+  async deleteContact(userId: number, contactId: number): Promise<void> {
+    const result = await this.contactRepository.deleteContactById(
+      userId,
+      contactId,
+    );
+    console.log('result', result);
+
+    if (result.affected === 0) {
+      throw new NotFoundException(`contactId ${contactId} does not exist`);
+    }
+  }
+
+  async changeSendingTarget(
+    userId: number,
+    changeSendingTargetDto: ChangeSendingTargetDto,
+  ): Promise<void> {
+    const { contactId, isSendingTarget } = changeSendingTargetDto;
+
+    await this.contactRepository.updateSendingTarget(
+      userId,
+      contactId,
+      isSendingTarget,
+    );
+    return;
+  }
+}

--- a/src/contact/dto/add-contact.dto.ts
+++ b/src/contact/dto/add-contact.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class AddContactDto {
+  @IsNotEmpty()
+  @IsString()
+  @ApiProperty({ description: '지인 이름', type: String })
+  name!: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @ApiProperty({ description: '지인 연락처', type: String })
+  phoneNumber!: string;
+}

--- a/src/contact/dto/change-sending-target.dto.ts
+++ b/src/contact/dto/change-sending-target.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+
+export class ChangeSendingTargetDto {
+  @IsNotEmpty()
+  @ApiProperty({ description: '연락처 id', type: Number })
+  contactId!: number;
+
+  @IsNotEmpty()
+  @ApiProperty({ description: '알림 전송 여부', type: Boolean })
+  isSendingTarget!: boolean;
+}

--- a/src/contact/dto/contact.dto.ts
+++ b/src/contact/dto/contact.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Relationship } from 'src/types/enums';
+
+export class ContactDto {
+  @ApiProperty({ description: '연락처 id', type: Number })
+  id!: number;
+
+  @ApiProperty({ description: '이름', type: String })
+  name!: string;
+
+  @ApiProperty({ description: '전화번호', type: String })
+  phoneNumber!: string;
+
+  @ApiProperty({
+    description: '관계',
+    enum: Relationship,
+    enumName: 'RelationShip',
+    nullable: true,
+  })
+  relationship!: Relationship | null;
+
+  @ApiProperty({ description: '알림 전송 여부', type: Boolean })
+  isSendingTarget!: boolean;
+
+  @ApiProperty({ description: '앱 등록 여부', type: Boolean })
+  isUser!: boolean;
+}
+
+export class ContactListDto {
+  @ApiProperty({ type: [ContactDto] })
+  contacts!: ContactDto[];
+}

--- a/src/repositories/contact.repository.ts
+++ b/src/repositories/contact.repository.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Contact } from 'src/entities/contact.entity';
+import { User } from 'src/entities/user.entity';
+import { DeleteResult, Repository } from 'typeorm';
+
+@Injectable()
+export class ContactRepository extends Repository<Contact> {
+  constructor(
+    @InjectRepository(Contact) private readonly repository: Repository<Contact>,
+  ) {
+    super(repository.target, repository.manager, repository.queryRunner);
+  }
+
+  async createContact(
+    user: User,
+    name: string,
+    phoneNumber: string,
+  ): Promise<void> {
+    const contact = this.repository.create({
+      user,
+      name,
+      phoneNumber,
+    });
+
+    try {
+      await this.repository.save(contact);
+    } catch (e) {
+      throw e;
+    }
+    return;
+  }
+
+  async getContacts(userId: number): Promise<Contact[]> {
+    return this.repository.find({ where: { user: { id: userId } } });
+  }
+
+  async findContactByPhoneNumber(
+    userId: number,
+    phoneNumber: string,
+  ): Promise<Contact> {
+    return this.repository.findOne({
+      where: { user: { id: userId }, phoneNumber },
+    });
+  }
+
+  async deleteContactById(
+    userId: number,
+    contactId: number,
+  ): Promise<DeleteResult> {
+    return this.repository.delete({ id: contactId, user: { id: userId } });
+  }
+
+  async updateSendingTarget(
+    userId: number,
+    contactId: number,
+    isSendingTarget: boolean,
+  ): Promise<void> {
+    const contact = await this.repository.findOne({
+      where: { id: contactId, user: { id: userId } },
+    });
+
+    contact.isSendingTarget = isSendingTarget;
+
+    try {
+      await this.repository.save(contact);
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  async getSendingTargetContacts(userId: number): Promise<Contact[]> {
+    return this.repository.find({
+      where: {
+        user: { id: userId },
+        isSendingTarget: true,
+      },
+    });
+  }
+}


### PR DESCRIPTION
- resolve #7 
- 지인 정보를 {이름, 전화번호}의 리스트로 받아와서 등록
- 지인 연락처 삭제
- 앱 등록 여부를 포함한 지인 리스트 조회
- 지인 별 알림 전송 여부 수정

을 구현하였습니다.

추가로 요청대로 contact repository에 유저 아이디를 받아서 알림을 보낼 연락처를 모두 불러오는 getSendingTargetContacts (함수 이름은 알아서 편한대로 수정해주세여) 를 구현하였습니다.